### PR TITLE
pull out epub renderers

### DIFF
--- a/pagetreeepub/renderers.py
+++ b/pagetreeepub/renderers.py
@@ -1,0 +1,20 @@
+# built-in and base renderer classes
+
+
+class BaseRenderer(object):
+    def __init__(self, block):
+        self.block = block
+
+    def render(self):
+        raise NotImplementedError
+
+
+class DefaultRenderer(BaseRenderer):
+    """ Default Pageblock Renderer
+
+    some simple pageblocks (TextBlock, HTMLBlock, etc.)
+    are really simple and we don't need to do anything
+    beyond just calling the block's existing .render() method
+    """
+    def render(self):
+        return self.block.render()

--- a/pagetreeepub/templates/epub/section.html
+++ b/pagetreeepub/templates/epub/section.html
@@ -14,11 +14,7 @@
   {% if block.unrenderable %}
     <p><i>Unrenderable Block: {{block.content_object.display_name}}</i></p>
   {% else %}
-    {% if block.is_image_block %}
-      <div><img src="{{block.epub_image_filename}}" /></div>
-    {% else %}
-      {{block.render|safe}}
-    {% endif %}
+      {{block.epub_content|safe}}
   {% endif %}
 
 {% endfor %}

--- a/pagetreeepub/tests/test_renderers.py
+++ b/pagetreeepub/tests/test_renderers.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from ..renderers import BaseRenderer, DefaultRenderer
+
+
+class DummyBlock(object):
+    def render(self):
+        return "I am a Dummy Block"
+
+
+class TestBaseRenderer(TestCase):
+    def test_create(self):
+        self.assertIsNotNone(BaseRenderer(DummyBlock()))
+
+    def test_cant_render(self):
+        r = BaseRenderer(DummyBlock())
+        with self.assertRaises(NotImplementedError):
+            r.render()
+
+
+class TestDefaultRenderer(TestCase):
+    def test_render(self):
+        r = DefaultRenderer(DummyBlock())
+        self.assertEqual(r.render(), "I am a Dummy Block")

--- a/pagetreeepub/tests/test_views.py
+++ b/pagetreeepub/tests/test_views.py
@@ -2,7 +2,7 @@ from django.test import RequestFactory
 from unittest import TestCase
 
 from ..views import (
-    is_block_allowed, is_image_block, EpubExporterView, depth_from_ai)
+    is_image_block, EpubExporterView, depth_from_ai)
 
 
 class DummyBlock(object):
@@ -17,12 +17,6 @@ class DummyBlock(object):
 
 
 class TestHelpers(TestCase):
-    def test_is_block_allowed(self):
-        d = DummyBlock("DummyBlock")
-        self.assertTrue(is_block_allowed(d))
-        d = DummyBlock("SomethingElse")
-        self.assertFalse(is_block_allowed(d))
-
     def test_is_image_block(self):
         d = DummyBlock("DummyBlock")
         self.assertFalse(is_image_block(d))


### PR DESCRIPTION
this gives us a mechanism to create custom renderers for existing
pageblocks without having to actually modify those pageblocks
themselves.

Eg, we could create a renderer for QuizBlock that renders all quizzes as
if they have `rhetorical` set (making them in-place JS quizzes for the
purpose of the epub). That wouldn't make sense to have in QuizBlock in
general, but might be reasonable for a particular project.

Implementing that would be something along the lines of:

```
from pagetreeepub.renderers import BaseRenderer

class QuizBlockRenderer(BaseRenderer):
    def render(self, block):
		    block.rhetorical = True
				return block.render()

... then in settings ...

EPUB_BLOCK_RENDERERS = {
    'Quiz Block': myapp.renderers.QuizBlockRenderer,
}
```

(in practice, we'd probably want to do something more complicated,
pulling in different templates and such as well).